### PR TITLE
Fix getPanning() for bg1

### DIFF
--- a/sdk/include/sifteo/video/bg1.h
+++ b/sdk/include/sifteo/video/bg1.h
@@ -456,7 +456,7 @@ struct BG1Drawable {
       * @brief Retrieve the last value set by setPanning().
      */
     Int2 getPanning() const {
-        unsigned word = _SYS_vbuf_peek(&sys.vbuf, offsetof(_SYSVideoRAM, bg0_x) / 2);
+        unsigned word = _SYS_vbuf_peek(&sys.vbuf, offsetof(_SYSVideoRAM, bg1_x) / 2);
         return vec<int>((int8_t)(word & 0xFF), (int8_t)(word >> 8));
     }
 


### PR DESCRIPTION
Fixed getPanning() for bg1. The original one returns the panning for bg0.